### PR TITLE
Multiline values without regexp

### DIFF
--- a/assets/.env
+++ b/assets/.env
@@ -19,3 +19,14 @@ QUOTE2= " OK 2 "
 QUOTE3= " OK ' 3 "
 QUOTE4= ' OK " 4 '
 QUOTE5= ' OK # 5 '
+
+MULTI_SPECIAL="
+1\"
+'2'
+#3"
+
+EMPTY=
+
+MULTILINE="1
+2
+3"

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -31,75 +31,125 @@ func (d Decoder) Decode(structure interface{}) error {
 
 // read scans a dot env (.env) file and extracts its key/value pairs.
 func (d Decoder) read(file *os.File) (map[string]string, error) {
-	kvs := map[string]string{}
 	scanner := bufio.NewScanner(file)
 
+	lines := make([]string, 0)
 	for i := 1; scanner.Scan(); i++ {
-		if k, v, err := d.parse(scanner.Text()); err != nil {
-			return nil, fmt.Errorf("dotenv: error in line %v; err: %v", i, err)
-		} else if k != "" {
-			kvs[k] = v
-		}
+		lines = append(lines, scanner.Text())
 	}
 
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("dotenv: error when scanning file; err: %v", err)
 	}
 
+	kvs, err := d.parseLines(lines)
+	if err != nil {
+		return nil, err
+	}
+
 	return kvs, nil
 }
 
-// parse extracts a key/value pair from the given dot env (.env) single line.
-func (d Decoder) parse(line string) (string, string, error) {
-	ln := strings.TrimSpace(line)
-	kv := []string{"", ""}
-	pi := 0
-	iq := false
-	qt := "'"
+// parseLines extracts a key/value pairs from the given dot env (.env).
+func (d Decoder) parseLines(lines []string) (map[string]string, error) {
+	kv := map[string]string{}
+	escape := "\\"
+	quote := ""
+	quoteWas := false
+	quoteOpen := false
+	key := ""
+	val := ""
+	valueMode := false
 
-	for i := 0; i < len(ln); i++ {
-		if string(ln[i]) == "#" && pi == 0 {
-			break
-		}
+	for l := 0; l < len(lines); l++ {
+		ln := strings.TrimSpace(lines[l])
 
-		if string(ln[i]) == "#" && pi == 1 && iq == false {
-			break
-		}
+		prev := ""
 
-		if string(ln[i]) == "=" && pi == 0 {
-			pi = 1
-			continue
-		}
+		for i := 0; i < len(ln); i++ {
 
-		if string(ln[i]) == " " && pi == 1 {
-			if iq == false && kv[pi] == "" {
-				continue
-			}
-		}
+			char := string(ln[i])
 
-		if (string(ln[i]) == "\"" || string(ln[i]) == "'") && pi == 1 {
-			if kv[pi] == "" {
-				iq = true
-				qt = string(ln[i])
-				continue
-			} else if iq == true && qt == string(ln[i]) {
+			// comment symbol
+			if char == "#" && (!valueMode || (valueMode && !quoteOpen)) {
 				break
 			}
+
+			// enable value mode
+			if char == "=" && !valueMode {
+				valueMode = true
+				continue
+			}
+
+			// skip space symbol in value mode
+			if char == " " && valueMode {
+				if !quoteOpen && val == "" {
+					continue
+				}
+			}
+
+			// quote symbols in value mode
+			if (char == "\"" || char == "'") && valueMode {
+				// if value is empty
+				if val == "" {
+					quoteOpen = true
+					quote = char
+					continue
+				}
+
+				// if close quote occurred
+				if quoteOpen && quote == char {
+					if prev != escape {
+						quoteOpen = false
+						quoteWas = true
+						break
+					}
+				}
+			}
+
+			if !valueMode {
+				key += char
+			}
+
+			if valueMode {
+				if i == 0 {
+					val += "\n"
+				}
+				if prev == escape && char == quote {
+					val = strings.TrimSuffix(val, escape)
+				}
+				val += char
+			}
+			prev = char
 		}
 
-		kv[pi] += string(ln[i])
+		// end of line
+		if !quoteOpen {
+			key = strings.TrimSpace(key)
+			if !quoteWas {
+				val = strings.TrimSpace(val)
+			}
+
+			if valueMode && key == "" {
+				return nil, fmt.Errorf("dotenv: invalid syntax in line %d", l)
+			}
+
+			if len(key) > 0 {
+				kv[key] = val
+				key = ""
+				val = ""
+			}
+			valueMode = false
+			quoteWas = false
+			quote = ""
+		}
 	}
 
-	kv[0] = strings.TrimSpace(kv[0])
-	if iq == false {
-		kv[1] = strings.TrimSpace(kv[1])
+	if quoteOpen {
+		return nil, fmt.Errorf("dotenv: invalid syntax")
 	}
 
-	if (pi == 0 && kv[0] != "") || (pi == 1 && kv[0] == "") {
-		return "", "", fmt.Errorf("dotenv: invalid syntax")
-	}
-
-	return kv[0], kv[1], nil
+	return kv, nil
 }
 
 // feed sets struct fields with the given key/value pairs.

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -28,6 +28,9 @@ type Config struct {
 		Quote4 string `env:"QUOTE4"`
 		Quote5 string `env:"QUOTE5"`
 	}
+	Empty        string `env:"EMPTY"`
+	Multiline    string `env:"MULTILINE"`
+	MultiSpecial string `env:"MULTI_SPECIAL"`
 }
 
 func TestLoad(t *testing.T) {
@@ -54,6 +57,9 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, " OK ' 3 ", c.QuoteBox.Quote3)
 	assert.Equal(t, " OK \" 4 ", c.QuoteBox.Quote4)
 	assert.Equal(t, " OK # 5 ", c.QuoteBox.Quote5)
+	assert.Equal(t, "1\n2\n3", c.Multiline)
+	assert.Equal(t, "", c.Empty)
+	assert.Equal(t, "\n1\"\n'2'\n#3", c.MultiSpecial)
 
 	err = f.Close()
 	assert.NoError(t, err)


### PR DESCRIPTION
Added ability to use multi-line values.

Unlike #1 version, this one does not use regex.